### PR TITLE
Update solr container for geoblacklight 1.0

### DIFF
--- a/images/solr/Dockerfile
+++ b/images/solr/Dockerfile
@@ -1,12 +1,11 @@
-FROM makuk66/docker-solr:5.2
+FROM solr:5
 
 MAINTAINER Eliot Jordan <eliot.jordan@gmail.com>
 
 USER root
 
 ENV PATH /opt/solr/bin:${PATH}
-ENV SCHEMA_VERSION 0.3.2
-ENV GBL_VERSION 0.10.2
+ENV GBL_VERSION 1.0.1
 ENV SOLR_HOME /var/solr/data/
 ENV GEO_CORE ${SOLR_HOME}geoblacklight/
 
@@ -15,9 +14,9 @@ RUN mkdir -p ${GEO_CORE}
 ADD solr.xml ${SOLR_HOME}
 ADD core.properties ${GEO_CORE}
 
-RUN curl -L https://github.com/geoblacklight/geoblacklight-schema/archive/v${SCHEMA_VERSION}.tar.gz | \
+RUN curl -L https://github.com/geoblacklight/geoblacklight/archive/v${GBL_VERSION}.tar.gz | \
     tar xz -C /tmp && \
-    mv /tmp/geoblacklight-schema-${SCHEMA_VERSION}/conf ${GEO_CORE}
+    mv /tmp/geoblacklight-${GBL_VERSION}/schema/solr/conf ${GEO_CORE}
 
 # Add start-up script
 ADD ./start.sh /opt/solr-5.2.1/start.sh


### PR DESCRIPTION
This updates the solr container to use the official solr base repo and the new geoblacklight 1.0 solr schema.